### PR TITLE
Multimask support for phone numbers

### DIFF
--- a/app/src/main/java/com/redmadrobot/sample/MainActivity.java
+++ b/app/src/main/java/com/redmadrobot/sample/MainActivity.java
@@ -26,6 +26,25 @@ public final class MainActivity extends Activity {
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+        setupPolymask();
+        setupMultimask();
+
+    }
+
+    private void setupMultimask() {
+        final EditText multiText = (EditText) findViewById(R.id.multimasked_et);
+        final Map<Integer, String> formats = new HashMap<>();
+        formats.put(7, "+7 ([000]) [000]-[00]-[00]");
+        formats.put(375, "+3[00] ([00]) [000]-[00]-[00]");
+
+        final MaskedTextChangedListener multilistener = new MultiPhoneMaskedTextChangedListener(
+                formats, multiText,
+                null);
+
+        multiText.addTextChangedListener(multilistener);
+    }
+
+    private void setupPolymask() {
         final EditText editText = (EditText) findViewById(R.id.polymasked_et);
         final List<String> affineFormats = new ArrayList<>();
         affineFormats.add("8 ([000]) [000] [000] [00]");
@@ -50,18 +69,6 @@ public final class MainActivity extends Activity {
         editText.setOnFocusChangeListener(listener);
 
         editText.setHint(listener.placeholder());
-
-        final EditText multiText = (EditText) findViewById(R.id.multimasked_et);
-        final Map<Integer, String> formats = new HashMap<>();
-        formats.put(7, "+7 ([000]) [000]-[00]-[00]");
-        formats.put(375, "+3[00] ([00]) [000]-[00]-[00]");
-
-        final MaskedTextChangedListener multilistener = new MultiPhoneMaskedTextChangedListener(
-                formats, multiText,
-                null);
-
-        multiText.addTextChangedListener(multilistener);
-
     }
 
 }

--- a/app/src/main/java/com/redmadrobot/sample/MainActivity.java
+++ b/app/src/main/java/com/redmadrobot/sample/MainActivity.java
@@ -1,7 +1,7 @@
 package com.redmadrobot.sample;
 
 import com.redmadrobot.inputmask.MaskedTextChangedListener;
-import com.redmadrobot.inputmask.MultiMaskedTextChangedListener;
+import com.redmadrobot.inputmask.MultiPhoneMaskedTextChangedListener;
 import com.redmadrobot.inputmask.PolyMaskTextChangedListener;
 
 import android.app.Activity;
@@ -56,11 +56,9 @@ public final class MainActivity extends Activity {
         formats.put(7, "+7 ([000]) [000]-[00]-[00]");
         formats.put(375, "+3[00] ([00]) [000]-[00]-[00]");
 
-        final MaskedTextChangedListener multilistener = new MultiMaskedTextChangedListener(
-                multiText,
-                null,
-                formats
-        );
+        final MaskedTextChangedListener multilistener = new MultiPhoneMaskedTextChangedListener(
+                formats, multiText,
+                null);
 
         multiText.addTextChangedListener(multilistener);
 

--- a/app/src/main/java/com/redmadrobot/sample/MainActivity.java
+++ b/app/src/main/java/com/redmadrobot/sample/MainActivity.java
@@ -1,6 +1,7 @@
 package com.redmadrobot.sample;
 
 import com.redmadrobot.inputmask.MaskedTextChangedListener;
+import com.redmadrobot.inputmask.MultiMaskedTextChangedListener;
 import com.redmadrobot.inputmask.PolyMaskTextChangedListener;
 
 import android.app.Activity;
@@ -10,7 +11,9 @@ import android.util.Log;
 import android.widget.EditText;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Home screen for the sample app.
@@ -23,7 +26,7 @@ public final class MainActivity extends Activity {
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-        final EditText editText = (EditText) findViewById(R.id.edit_text);
+        final EditText editText = (EditText) findViewById(R.id.polymasked_et);
         final List<String> affineFormats = new ArrayList<>();
         affineFormats.add("8 ([000]) [000] [000] [00]");
 
@@ -47,6 +50,20 @@ public final class MainActivity extends Activity {
         editText.setOnFocusChangeListener(listener);
 
         editText.setHint(listener.placeholder());
+
+        final EditText multiText = (EditText) findViewById(R.id.multimasked_et);
+        final Map<Integer, String> formats = new HashMap<>();
+        formats.put(7, "+7 ([000]) [000]-[00]-[00]");
+        formats.put(375, "+3[00] ([00]) [000]-[00]-[00]");
+
+        final MaskedTextChangedListener multilistener = new MultiMaskedTextChangedListener(
+                multiText,
+                null,
+                formats
+        );
+
+        multiText.addTextChangedListener(multilistener);
+
     }
 
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,34 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingStart="16dp"
-    android:paddingEnd="16dp">
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:orientation="vertical"
+              android:padding="16dp">
+
+    <TextView
+        android:textSize="20sp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="Sample"/>
 
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
         android:gravity="center"
         android:text="@string/polymasked_label"/>
 
     <EditText
         android:id="@+id/polymasked_et"
         android:layout_width="match_parent"
-        android:inputType="phone"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:inputType="phone"/>
 
     <TextView
-        android:gravity="center"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:gravity="center"
         android:text="@string/multimasked_label"/>
 
     <EditText
         android:id="@+id/multimasked_et"
         android:layout_width="match_parent"
-        android:inputType="phone"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:inputType="phone"/>
 
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,12 +10,25 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center"
-        android:text="@string/sample"/>
+        android:text="@string/polymasked_label"/>
 
     <EditText
-        android:id="@+id/edit_text"
+        android:id="@+id/polymasked_et"
         android:layout_width="match_parent"
         android:inputType="phone"
         android:layout_height="wrap_content" />
+
+    <TextView
+        android:gravity="center"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/multimasked_label"/>
+
+    <EditText
+        android:id="@+id/multimasked_et"
+        android:layout_width="match_parent"
+        android:inputType="phone"
+        android:layout_height="wrap_content" />
+
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
     <string name="app_name">InputMask</string>
     <string name="polymasked_label">Polymasked text listener</string>
-    <string name="multimasked_label">Multi-Masked text listener</string>
+    <string name="multimasked_label">Multi-Masked text listener\n Example formats:\n+7 ([000]) [000]-[00]-[00],\n+375 ([00]) [000]-[00]-[00]</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">InputMask</string>
-    <string name="sample">Sample</string>
+    <string name="polymasked_label">Polymasked text listener</string>
+    <string name="multimasked_label">Multi-Masked text listener</string>
 </resources>

--- a/inputmask/src/main/kotlin/com/redmadrobot/inputmask/MaskedTextChangedListener.kt
+++ b/inputmask/src/main/kotlin/com/redmadrobot/inputmask/MaskedTextChangedListener.kt
@@ -13,12 +13,12 @@ import java.lang.ref.WeakReference
  *
  * Created by taflanidi on 30.08.16.
  */
-open class MaskedTextChangedListener(
+open class MaskedTextChangedListener @JvmOverloads constructor(
         format: String,
-        autocomplete: Boolean,
+        autocomplete: Boolean = true,
         field: EditText,
-        listener: TextWatcher?,
-        valueListener: ValueListener?
+        listener: TextWatcher? = null,
+        valueListener: ValueListener? = null
 ) : TextWatcher, View.OnFocusChangeListener {
 
     interface ValueListener {

--- a/inputmask/src/main/kotlin/com/redmadrobot/inputmask/MaskedTextChangedListener.kt
+++ b/inputmask/src/main/kotlin/com/redmadrobot/inputmask/MaskedTextChangedListener.kt
@@ -28,7 +28,7 @@ open class MaskedTextChangedListener(
     var listener: TextWatcher?
     var valueListener: ValueListener?
 
-    val mask: Mask
+    var mask: Mask
     val autocomplete: Boolean
 
     var afterText: String = ""

--- a/inputmask/src/main/kotlin/com/redmadrobot/inputmask/MultiMaskTextChagedListener.kt
+++ b/inputmask/src/main/kotlin/com/redmadrobot/inputmask/MultiMaskTextChagedListener.kt
@@ -5,15 +5,18 @@ import android.widget.EditText
 import com.redmadrobot.inputmask.helper.Mask
 
 /**
+ *
  * @author aleien on 14.09.17.
  */
-class MultiMaskedTextChangedListener(input: EditText, listener: TextWatcher?, formats: Map<Int, String>) : MaskedTextChangedListener("+7 ([000]) [000]-[00]-[00]",
-        true, input,
-        listener, null) {
 
-    private val maskPlusANY: Mask = Mask.getOrCreate("+[000000000000000]")
-    private val maskANY = Mask.getOrCreate("[000000000000000]")
-    private val masks: Map<Int, Mask> = formats.mapValues { entry -> Mask.getOrCreate(entry.value) }. plus('+'.toInt() to maskPlusANY)
+class MultiPhoneMaskedTextChangedListener @JvmOverloads constructor(formats: Map<Int, String>,
+       input: EditText, listener: TextWatcher?, autocomplete: Boolean = true, valueListener: ValueListener? = null) :
+        MaskedTextChangedListener(DEFAULT_PLUS, autocomplete, input, listener, valueListener) {
+
+    private val maskPlusDefault: Mask = Mask.getOrCreate(DEFAULT_PLUS)
+    private val maskDefault = Mask.getOrCreate(DEFAULT_DIGITS)
+
+    private val masks: Map<Int, Mask> = formats.mapValues { entry -> Mask.getOrCreate(entry.value) }
 
     private fun CharSequence.firstDigitsAre(i: Int): Boolean {
         if (this.isBlank()) return false
@@ -24,7 +27,8 @@ class MultiMaskedTextChangedListener(input: EditText, listener: TextWatcher?, fo
 
 
     override fun onTextChanged(text: CharSequence, cursorPosition: Int, before: Int, count: Int) {
-        mask = if (text.startsWith('+')) maskPlusANY else maskANY
+        mask = if (text.startsWith(PLUS_CHAR)) maskPlusDefault else maskDefault
+
         // we shouldn't use masks.forEach here, because it'll crash on sdk < 19
         for ((key, value) in masks) {
             if (text.firstDigitsAre(key)) {
@@ -36,3 +40,7 @@ class MultiMaskedTextChangedListener(input: EditText, listener: TextWatcher?, fo
         super.onTextChanged(text, cursorPosition, before, count)
     }
 }
+
+const val DEFAULT_PLUS = "+[000000000000000]"
+const val DEFAULT_DIGITS = "[000000000000000]"
+const val PLUS_CHAR = '+'

--- a/inputmask/src/main/kotlin/com/redmadrobot/inputmask/MultiMaskTextChagedListener.kt
+++ b/inputmask/src/main/kotlin/com/redmadrobot/inputmask/MultiMaskTextChagedListener.kt
@@ -1,0 +1,38 @@
+package com.redmadrobot.inputmask
+
+import android.text.TextWatcher
+import android.widget.EditText
+import com.redmadrobot.inputmask.helper.Mask
+
+/**
+ * @author aleien on 14.09.17.
+ */
+class MultiMaskedTextChangedListener(input: EditText, listener: TextWatcher?, formats: Map<Int, String>) : MaskedTextChangedListener("+7 ([000]) [000]-[00]-[00]",
+        true, input,
+        listener, null) {
+
+    private val maskPlusANY: Mask = Mask.getOrCreate("+[000000000000000]")
+    private val maskANY = Mask.getOrCreate("[000000000000000]")
+    private val masks: Map<Int, Mask> = formats.mapValues { entry -> Mask.getOrCreate(entry.value) }. plus('+'.toInt() to maskPlusANY)
+
+    private fun CharSequence.firstDigitsAre(i: Int): Boolean {
+        if (this.isBlank()) return false
+        val phone = this.filter { it.isDigit() }.toString()
+        if (phone.isBlank()) return false
+        return phone.startsWith(i.toString())
+    }
+
+
+    override fun onTextChanged(text: CharSequence, cursorPosition: Int, before: Int, count: Int) {
+        mask = if (text.startsWith('+')) maskPlusANY else maskANY
+        // we shouldn't use masks.forEach here, because it'll crash on sdk < 19
+        for ((key, value) in masks) {
+            if (text.firstDigitsAre(key)) {
+                mask = value
+                break
+            }
+        }
+
+        super.onTextChanged(text, cursorPosition, before, count)
+    }
+}


### PR DESCRIPTION
Added support for using several mask variants for phone numbers (so that user of library wouldn't have to choose mask some other way, i.e. with spinner).
Mask is chosen based on specified phone starting digits.

=====================
What I meant to say:
Возможность задать несколько вариантов масок для номеров телефонов (чтобы не приходилось выбирать маску каким-то другим способом).
Выбор маски задается указанием цифр, с которых должен начинаться номер, чтобы сработала желаемая маска.