### PR TITLE
Deletion detection adjusted in MaskedTextChangedListener

### DIFF
--- a/inputmask/src/main/kotlin/com/redmadrobot/inputmask/MaskedTextChangedListener.kt
+++ b/inputmask/src/main/kotlin/com/redmadrobot/inputmask/MaskedTextChangedListener.kt
@@ -120,7 +120,7 @@ open class MaskedTextChangedListener(
     }
 
     override fun onTextChanged(text: CharSequence, cursorPosition: Int, before: Int, count: Int) {
-        val isDeletion: Boolean = before > 0
+        val isDeletion: Boolean = before > 0 && count == 0
         val result: Mask.Result =
                 this.mask.apply(
                         CaretString(


### PR DESCRIPTION
Resolves cursor jumps when symbols replacement happens in MaskedTextChangedListener.onTextChanged().
Described and discussed in issue #49 