### PR TITLE
Adjusted gradle installation tutorial to latest version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.redmadrobot:inputmask:3.3.0'
+    implementation 'com.redmadrobot:inputmask:3.4.0'
 }
 ```
 


### PR DESCRIPTION
Latest version is 3.4.0, not 3.3.0. Update docu: https://github.com/RedMadRobot/input-mask-android/releases/tag/3.4.0

See my issue, too: https://github.com/RedMadRobot/input-mask-android/issues/54