### PR TITLE
Added formattedText to MaskedTextChangedListener.ValueListener::onTextChanged 

### DIFF
--- a/app/src/main/java/com/redmadrobot/sample/MainActivity.java
+++ b/app/src/main/java/com/redmadrobot/sample/MainActivity.java
@@ -43,9 +43,7 @@ public final class MainActivity extends Activity {
             new MaskedTextChangedListener.ValueListener() {
                 @Override
                 public void onTextChanged(boolean maskFilled, @NonNull final String extractedValue, @NonNull String formattedText) {
-                    Log.d(MainActivity.class.getSimpleName(), extractedValue);
-                    Log.d(MainActivity.class.getSimpleName(), String.valueOf(maskFilled));
-                    Log.d(MainActivity.class.getSimpleName(), String.valueOf(formattedText));
+                    logValueListener(maskFilled, extractedValue, formattedText);
                     checkBox.setChecked(maskFilled);
                 }
             }
@@ -68,15 +66,20 @@ public final class MainActivity extends Activity {
                 new MaskedTextChangedListener.ValueListener() {
                     @Override
                     public void onTextChanged(boolean maskFilled, @NonNull final String extractedValue, @NonNull String formattedText) {
-                        Log.d(MainActivity.class.getSimpleName(), extractedValue);
-                        Log.d(MainActivity.class.getSimpleName(), String.valueOf(maskFilled));
-                        Log.d(MainActivity.class.getSimpleName(), String.valueOf(formattedText));
+                        logValueListener(maskFilled, extractedValue, formattedText);
                         checkBox.setChecked(maskFilled);
                     }
                 }
         );
 
         editText.setHint(listener.placeholder());
+    }
+
+    private void logValueListener(boolean maskFilled, @NonNull String extractedValue, @NonNull String formattedText) {
+        final String className = MainActivity.class.getSimpleName();
+        Log.d(className, extractedValue);
+        Log.d(className, String.valueOf(maskFilled));
+        Log.d(className, String.valueOf(formattedText));
     }
 
 }

--- a/app/src/main/java/com/redmadrobot/sample/MainActivity.java
+++ b/app/src/main/java/com/redmadrobot/sample/MainActivity.java
@@ -42,9 +42,10 @@ public final class MainActivity extends Activity {
             AffinityCalculationStrategy.PREFIX,
             new MaskedTextChangedListener.ValueListener() {
                 @Override
-                public void onTextChanged(boolean maskFilled, @NonNull final String extractedValue) {
+                public void onTextChanged(boolean maskFilled, @NonNull final String extractedValue, @NonNull String formattedText) {
                     Log.d(MainActivity.class.getSimpleName(), extractedValue);
                     Log.d(MainActivity.class.getSimpleName(), String.valueOf(maskFilled));
+                    Log.d(MainActivity.class.getSimpleName(), String.valueOf(formattedText));
                     checkBox.setChecked(maskFilled);
                 }
             }
@@ -66,9 +67,10 @@ public final class MainActivity extends Activity {
                 AffinityCalculationStrategy.WHOLE_STRING,
                 new MaskedTextChangedListener.ValueListener() {
                     @Override
-                    public void onTextChanged(boolean maskFilled, @NonNull final String extractedValue) {
+                    public void onTextChanged(boolean maskFilled, @NonNull final String extractedValue, @NonNull String formattedText) {
                         Log.d(MainActivity.class.getSimpleName(), extractedValue);
                         Log.d(MainActivity.class.getSimpleName(), String.valueOf(maskFilled));
+                        Log.d(MainActivity.class.getSimpleName(), String.valueOf(formattedText));
                         checkBox.setChecked(maskFilled);
                     }
                 }

--- a/inputmask/src/main/kotlin/com/redmadrobot/inputmask/MaskedTextChangedListener.kt
+++ b/inputmask/src/main/kotlin/com/redmadrobot/inputmask/MaskedTextChangedListener.kt
@@ -9,7 +9,7 @@ import com.redmadrobot.inputmask.helper.Mask
 import com.redmadrobot.inputmask.model.CaretString
 import com.redmadrobot.inputmask.model.Notation
 import java.lang.ref.WeakReference
-import java.util.ArrayList
+import java.util.*
 
 /**
  * TextWatcher implementation.
@@ -30,7 +30,7 @@ open class MaskedTextChangedListener(
 ) : TextWatcher, View.OnFocusChangeListener {
 
     interface ValueListener {
-        fun onTextChanged(maskFilled: Boolean, extractedValue: String)
+        fun onTextChanged(maskFilled: Boolean, extractedValue: String, formattedValue: String)
     }
 
     private val primaryMask: Mask
@@ -102,7 +102,8 @@ open class MaskedTextChangedListener(
     open fun setText(text: String): Mask.Result? {
         return this.field.get()?.let {
             val result = setText(text, it)
-            this.valueListener?.onTextChanged(result.complete, result.extractedValue)
+            this.afterText = result.formattedText.string
+            this.valueListener?.onTextChanged(result.complete, result.extractedValue, afterText)
             return result
         }
     }
@@ -190,7 +191,7 @@ open class MaskedTextChangedListener(
             )
         this.afterText = result.formattedText.string
         this.caretPosition = if (isDeletion) cursorPosition else result.formattedText.caretPosition
-        this.valueListener?.onTextChanged(result.complete, result.extractedValue)
+        this.valueListener?.onTextChanged(result.complete, result.extractedValue, afterText)
     }
 
     override fun onFocusChange(view: View?, hasFocus: Boolean) {
@@ -206,9 +207,11 @@ open class MaskedTextChangedListener(
                     CaretString(text, text.length),
                     this.autocomplete
                 )
-            this.field.get()?.setText(result.formattedText.string)
+
+            this.afterText = result.formattedText.string
+            this.field.get()?.setText(afterText)
             this.field.get()?.setSelection(result.formattedText.caretPosition)
-            this.valueListener?.onTextChanged(result.complete, result.extractedValue)
+            this.valueListener?.onTextChanged(result.complete, result.extractedValue, afterText)
         }
     }
 

--- a/inputmask/src/main/kotlin/com/redmadrobot/inputmask/MaskedTextChangedListener.kt
+++ b/inputmask/src/main/kotlin/com/redmadrobot/inputmask/MaskedTextChangedListener.kt
@@ -103,6 +103,7 @@ open class MaskedTextChangedListener(
         return this.field.get()?.let {
             val result = setText(text, it)
             this.afterText = result.formattedText.string
+            this.caretPosition = result.formattedText.caretPosition
             this.valueListener?.onTextChanged(result.complete, result.extractedValue, afterText)
             return result
         }
@@ -209,6 +210,7 @@ open class MaskedTextChangedListener(
                 )
 
             this.afterText = result.formattedText.string
+            this.caretPosition = result.formattedText.caretPosition
             this.field.get()?.setText(afterText)
             this.field.get()?.setSelection(result.formattedText.caretPosition)
             this.valueListener?.onTextChanged(result.complete, result.extractedValue, afterText)


### PR DESCRIPTION
There are cases when having actual formatted text along with extracted value inside `MaskedTextChangedListener.ValueListener::onTextChanged` is necessary. So there is a suggestion to add `formattedText: String` to `MaskedTextChangedListener.ValueListener::onTextChanged`.
Conceptually there is nothing wrong in having this param on text changes + given the listener is passed inside `MaskedTextChangedListener`s ctor such signature change seems legit.

Also I added `afterText` assignments into `setText` and `onFocusChange ` as there are calls to `valueListener?.onTextChanged` and logically these calls should go paired with `afterText` assignment as it was done inside `onTextChanged`.

So take a look please.