### PR TITLE
Fix publish configuration

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -15,7 +15,7 @@ group publishProperties['group_id']
 publishing {
     publications {
         Production(MavenPublication) {
-            artifact("$buildDir/outputs/aar/acronymavatar-release.aar")
+            artifact("$buildDir/outputs/aar/inputmask-release.aar")
             groupId
             artifactId publishProperties['lib_name']
             version this.version
@@ -56,7 +56,7 @@ bintray {
         publicDownloadNumbers = true
 
         // set as true to test uploading
-        dryRun = false
+        dryRun = true
 
         version {
             name = this.version

--- a/inputmask/build.gradle
+++ b/inputmask/build.gradle
@@ -2,6 +2,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'org.jetbrains.dokka'
 
+apply from: '../gradle/publish.gradle'
+
 android {
     compileSdkVersion build_versions.compile_sdk
 


### PR DESCRIPTION
Pay your attention to `dryRun` flag in the `publish.gradle` file.