### PR TITLE
Change library group to `com.redmadrobot`

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.RedMadRobot:input-mask-android:6.1.0'
+    implementation 'com.redmadrobot:input-mask-android:6.1.0'
     
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:$latest_version'
 }


### PR DESCRIPTION
@taflanidi, FYI, we've added DNS record to be able to use `com.redmadrobot` package on jitpack.io
So, input-mask can be accessed by [com.redmadrobot:input-mask-android](https://jitpack.io/#com.redmadrobot/input-mask-android) coordinates