### PR TITLE
fix ConcurrentModificationException when other text watchers are installed

### DIFF
--- a/inputmask/src/main/kotlin/com/redmadrobot/inputmask/MaskedTextChangedListener.kt
+++ b/inputmask/src/main/kotlin/com/redmadrobot/inputmask/MaskedTextChangedListener.kt
@@ -47,6 +47,7 @@ open class MaskedTextChangedListener(
 
     private var afterText: String = ""
     private var caretPosition: Int = 0
+    private var textWatcherCallbacksEnabled: Boolean = true
 
     private val field: WeakReference<EditText> = WeakReference(field)
 
@@ -209,7 +210,11 @@ open class MaskedTextChangedListener(
     fun totalValueLength(): Int = this.primaryMask.totalValueLength()
 
     override fun afterTextChanged(edit: Editable?) {
-        this.field.get()?.removeTextChangedListener(this)
+        if (!textWatcherCallbacksEnabled) {
+            return
+        }
+
+        textWatcherCallbacksEnabled = false
         edit?.replace(0, edit.length, this.afterText)
 
         try {
@@ -228,15 +233,23 @@ open class MaskedTextChangedListener(
             )
         }
 
-        this.field.get()?.addTextChangedListener(this)
+        textWatcherCallbacksEnabled = true
         this.listener?.afterTextChanged(edit)
     }
 
     override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+        if (!textWatcherCallbacksEnabled) {
+            return
+        }
+
         this.listener?.beforeTextChanged(s, start, count, after)
     }
 
     override fun onTextChanged(text: CharSequence, cursorPosition: Int, before: Int, count: Int) {
+        if (!textWatcherCallbacksEnabled) {
+            return
+        }
+
         val isDeletion: Boolean = before > 0 && count == 0
         val useAutocomplete = if (isDeletion) false else this.autocomplete
         val useAutoskip = if (isDeletion) this.autoskip else false


### PR DESCRIPTION
I experienced this in a react-native app when using another library, LogRocket, which globally scans for text views to install their own text watcher for analytics purposes.

And along with react-native, I have these installed as well:

* [react-native-text-input-mask](https://github.com/react-native-text-input-mask/react-native-text-input-mask), which uses this library.
* [@logrocket/react-native](https://www.npmjs.com/package/@logrocket/react-native), which installs its own text watcher on all edit text views.

What triggers the crash is:

1.  when the React Native text component [loops over an iterator](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java#L1376)
2. this library's `afterTextChanged` is called which modifies the list while it's being iterated
3. there are any other text watchers (e.g. LogRocket) that come after this one in the list.
4. the iterator will try to fetch its next element, which fails with `ConcurrentModificationException` during the [check for comodification](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/util/ArrayList.java#L1050).

If not for (3), the crash is avoided.

With this PR, I was able to substitute this library out for a patched one and confirmed it fixes the issue.

Let me know if you need anything else.